### PR TITLE
修复爬取失败后引起的空指针异常

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -40,7 +40,8 @@ func Fetch(url string) *goquery.Document {
 	}
 	defer func() {
 		if err := recover(); err != nil {
-			fmt.Print("起死回生")
+			fmt.Println("fetch error")
+			fmt.Println(err)
 		}
 	}()
 	if err != nil {

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -40,7 +40,7 @@ func Fetch(url string) *goquery.Document {
 	}
 	defer func() {
 		if err := recover(); err != nil {
-			fmt.Println("fetch error")
+			fmt.Print("起死回生")
 			fmt.Println(err)
 		}
 	}()

--- a/fetcher/ip3366/ip3366.go
+++ b/fetcher/ip3366/ip3366.go
@@ -23,7 +23,10 @@ func Ip33662() []*ipModel.IP {
 
 func Ip3366(proxyType int) []*ipModel.IP {
 	logger.Info("[ip3366] fetch start")
-
+	defer func() {
+		recover()
+		logger.Warnln("[ip3366] fetch error")
+	}()
 	list := make([]*ipModel.IP, 0)
 
 	indexUrl := "http://www.ip3366.net/free"

--- a/fetcher/ip66/ip66.go
+++ b/fetcher/ip66/ip66.go
@@ -13,7 +13,10 @@ import (
 
 func Ip66() []*ipModel.IP {
 	logger.Info("[66ip] fetch start")
-
+	defer func() {
+		recover()
+		logger.Warnln("[66ip] fetch error")
+	}()
 	list := make([]*ipModel.IP, 0)
 
 	indexUrl := "http://www.66ip.cn"

--- a/fetcher/ip89/ip89.go
+++ b/fetcher/ip89/ip89.go
@@ -13,7 +13,10 @@ import (
 
 func Ip89() []*ipModel.IP {
 	logger.Info("[89ip] fetch start")
-
+	defer func() {
+		recover()
+		logger.Warnln("[89ip] fetch error")
+	}()
 	list := make([]*ipModel.IP, 0)
 
 	indexUrl := "https://www.89ip.cn/"


### PR DESCRIPTION
fix #56

`fetcher/fetcher.go:16` Fetch方法的panic执行recover之后返回nil，导致调用方的空指针异常，因此在调用方加上recover，若爬取失败直接返回空切片